### PR TITLE
Enables library to act as a 'reference implementation'

### DIFF
--- a/python/aces/clf/ASCCDL.py
+++ b/python/aces/clf/ASCCDL.py
@@ -55,6 +55,8 @@ WHETHER DISCLOSED OR UNDISCLOSED.
 import xml.etree.ElementTree as etree
 
 from ProcessNode import *
+from Common import getFeatureCompatibility, featureSets
+import Errors
 
 class ASCCDL(ProcessNode):
     "A Common LUT Format ASC_CDL ProcessNode element"
@@ -133,6 +135,11 @@ class ASCCDL(ProcessNode):
         # Node attributes
         style = ''
         if 'style' in self._attributes: style = self._attributes['style']
+
+        if (not(getFeatureCompatibility() & featureSets["Autodesk"]) and
+            style in ['v1.2_Fwd', 'noClampFwd', 'v1.2_Rev', 'noClampRev']):
+                msg = "Unsupported feature : Autodesk CDL style keyword %s" % style
+                raise Errors.UnsupportedExtensionError(msg)
 
         # Node parameters
         slope = [1.0, 1.0, 1.0]

--- a/python/aces/clf/Common.py
+++ b/python/aces/clf/Common.py
@@ -52,9 +52,28 @@ IMPLEMENTATION, OR APPLICATIONS THEREOF, HELD BY PARTIES OTHER THAN A.M.P.A.S.,
 WHETHER DISCLOSED OR UNDISCLOSED.
 """
 
+import numpy as np
 import struct
 
-import numpy as np
+#
+# Functions to manage which feature sets are supported at run-time
+#
+featureSets = {
+    "CLF"              : 0x0, 
+    "Autodesk"         : 0x1,
+    "Duiker Research"  : 0x2,
+    "All"              : 0xf
+}
+
+compatibility = featureSets["All"]
+
+def setFeatureCompatibility(featureSet):
+    global compatibility
+    compatibility = featureSet
+
+def getFeatureCompatibility():
+    global compatibility
+    return compatibility
 
 # Simple utility functions
 def clamp(value, minValue=0.0, maxValue=1.0):

--- a/python/aces/clf/Errors.py
+++ b/python/aces/clf/Errors.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+class Error(Exception):
+    """Base class for exceptions in this module."""
+    pass
+
+class UnknownProcessNodeError(Error):
+    """Exception raised for ProcessNodes types that are unknown or unsupported.
+
+    Attributes:
+        expr -- input expression in which the error occurred
+        msg  -- explanation of the error
+    """
+
+    def __init__(self, msg):
+        self.msg = msg
+    def __str__(self):
+        return repr(self.msg)
+
+class UnsupportedExtensionError(Error):
+    """Exception raised for errors related to unsupported extensions.
+
+    Attributes:
+        expr -- input expression in which the error occurred
+        msg  -- explanation of the error
+    """
+
+    def __init__(self, msg):
+        self.msg = msg
+    def __str__(self):
+        return repr(self.msg)

--- a/python/aces/clf/ExtensionReference.py
+++ b/python/aces/clf/ExtensionReference.py
@@ -136,6 +136,8 @@ class Reference(ProcessNode):
             print( "Reference processing - begin" )
         if self._processList != None:
             outValues = self._processList.process(values, stride, verbose=verbose)
+        else:
+            outValues = values
         if verbose:
             print( "Reference processing - end\n" )
         return outValues

--- a/python/aces/clf/ProcessNode.py
+++ b/python/aces/clf/ProcessNode.py
@@ -60,6 +60,7 @@ import xml.etree.ElementTree as etree
 # General Types
 from Comment import Description
 from Common import *
+import Errors
 
 from ProcessList import ProcessListChildMeta
 
@@ -183,7 +184,7 @@ class ProcessNode():
     def readInitialize(self):
         return None
 
-    def read(self, element):
+    def read(self, element, strict=False):
         #print( "%s - ProcessNode::read" % element.tag)
         # Store attributes
         for key, value in element.attrib.iteritems():
@@ -205,9 +206,16 @@ class ProcessNode():
 
             # Read DynamicParameter elements
             elif childType == 'DynamicParameter':
-                for key, value in child.attrib.iteritems():
-                    if key == 'param':
-                        self._dynamicParams.append(value)
+                if getFeatureCompatibility() & featureSets["Autodesk"]:
+                    for key, value in child.attrib.iteritems():
+                        if key == 'param':
+                            self._dynamicParams.append(value)
+                else:
+                    msg = "Unsupported feature : DynamicParameter element"
+                    if strict:
+                        raise Errors.UnsupportedExtensionError(msg)
+                    else:
+                        print( "ProcessNode::read - %s" % msg )
 
             # Otherwise, allow the subclasses to read elements
             else:
@@ -288,7 +296,7 @@ class ProcessNode():
     # Color processing
     def process(self, values, stride=0, verbose=False):
         if verbose:
-            print( "ProcessNode::process - processing bypassed")
+            print( "ProcessNode::process - no op")
         return value
 
     # Setters and getters

--- a/python/aces/clf/__init__.py
+++ b/python/aces/clf/__init__.py
@@ -124,6 +124,9 @@ __version__ = '.'.join((__major_version__,
 Having the explicit imports here feels off, but also necessary...
 '''
 
+# Feature set compatibility
+from Common import setFeatureCompatibility, getFeatureCompatibility, featureSets
+
 # General Types
 from ProcessList import ProcessList
 from Comment import Description, InputDescriptor, OutputDescriptor

--- a/python/aces/clf/tests/UnitTestsCLF.py
+++ b/python/aces/clf/tests/UnitTestsCLF.py
@@ -121,6 +121,19 @@ class TestCLF(unittest.TestCase):
         os.unlink(cls._tmpclfz)
 
     def createCLF(self, clfPath):
+        # If you want to restrict feature compatibility for some reason,
+        # use one of these lines
+        # setFeatureCompatibility(featureSets["Autodesk"])
+        # setFeatureCompatibility(featureSets["Duiker Research"])
+        # 
+        # The following setting will cause the library to act like a
+        # true reference implementation of the CLF spec. Only features included
+        # in the specification will be supported
+        #setFeatureCompatibility(featureSets["CLF"])
+        #
+        # The default setting supports all extensions. This is equivalent to
+        setFeatureCompatibility(featureSets["All"])
+
         pl = ProcessList()
 
         # Populate


### PR DESCRIPTION
Hey,

Please accept this pull request. I added feature that will allow the library to act as a true 'reference implementation', turning on or off support for feature extensions implemented by Autodesk and Duiker Research.

The default is to support the extensions, but that could be changed with the setting of one variable.

Thanks,
HP